### PR TITLE
Use environment variables for credentials

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,6 +18,9 @@ jobs:
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
     - name: Run Playwright tests
+      env:
+        PLAYWRIGHT_USERNAME: ${{ vars.PLAYWRIGHT_USERNAME }}
+        PLAYWRIGHT_PASSWORD: ${{ secrets.PLAYWRIGHT_PASSWORD }}
       run: npx playwright test
     - uses: actions/upload-artifact@v4
       if: always()

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "playwright-demo",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
       "devDependencies": {
         "@playwright/test": "^1.44.0",
         "@types/node": "^20.12.11"
@@ -35,6 +38,17 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/fsevents": {

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   "devDependencies": {
     "@playwright/test": "^1.44.0",
     "@types/node": "^20.12.11"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,7 @@ import { defineConfig, devices } from '@playwright/test';
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-// require('dotenv').config();
+require('dotenv').config();
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -1,7 +1,15 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Log in to Swag Labs', () => {
-  
+
+  // get user and password from env variables
+  const username = process.env.PLAYWRIGHT_USERNAME;
+  const password = process.env.PLAYWRIGHT_PASSWORD;
+
+  // ensure that username and password are defined
+  expect(username).not.toBe(undefined);
+  expect(password).not.toBe(undefined);
+
   test.beforeEach(async ({ page }) => {
     await page.goto('https://www.saucedemo.com/');
     await expect(page).toHaveTitle(/Swag Labs/);
@@ -12,8 +20,8 @@ test.describe('Log in to Swag Labs', () => {
   });
 
   test('login using valid credentials', async ({ page }) => {  
-    await page.getByPlaceholder('Username').fill('standard_user');
-    await page.getByPlaceholder('Password').fill('secret_sauce');
+    await page.getByPlaceholder('Username').fill(username!);
+    await page.getByPlaceholder('Password').fill(password!);
     await page.getByRole('button', { name: 'Login' }).click();
     await expect(page.getByText('Products')).toBeVisible();
   });


### PR DESCRIPTION
- Installed [dotenv](https://www.npmjs.com/package/dotenv) package
- Replaced hardcoded credentials with environment variables in log in tests